### PR TITLE
Docker Compose File

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -7,3 +7,15 @@ services:
       - 80:80
     volumes:
       - ./Connect4ProjectWebGUI:/var/www/html
+
+  db:
+    image: mariadb
+    ports:
+      - 3306:3306
+    environment:
+      MARIADB_ROOT_PASSWORD: pass
+
+  adminer:
+    image: adminer
+    ports:
+      - 8080:8080

--- a/compose.yml
+++ b/compose.yml
@@ -13,7 +13,10 @@ services:
     ports:
       - 3306:3306
     environment:
-      MARIADB_ROOT_PASSWORD: pass
+      MARIADB_RANDOM_ROOT_PASSWORD: 1
+      MARIADB_DATABASE: "c4db"
+      MARIADB_USER: "c4db"
+      MARIADB_PASSWORD: "c4db"
 
   adminer:
     image: adminer

--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,9 @@
+name: cis17b_connect4_final
+
+services:
+  web:
+    image: php:8.3.7-apache
+    ports:
+      - 80:80
+    volumes:
+      - ./Connect4ProjectWebGUI:/var/www/html


### PR DESCRIPTION
Adds a compose.yml file to run the PHP web server and SQL database. Start the containers by running `docker compose up -d` . Project pages are hosted at http://localhost and a MariaDB admin dashboard is available at http://localhost:8080.